### PR TITLE
fix: no images shown when building for ios9

### DIFF
--- a/MMParallaxCell/MMParallaxCell/Info.plist
+++ b/MMParallaxCell/MMParallaxCell/Info.plist
@@ -22,6 +22,11 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
fix: no images shown when building for ios9 
Adding NSAppTransportSecurity key to info.plist made it work
