### PR TITLE
Fix for Retain Cycle

### DIFF
--- a/Classes/MMParallaxCell.h
+++ b/Classes/MMParallaxCell.h
@@ -14,6 +14,26 @@
 
 @property (nonatomic, assign) CGFloat parallaxRatio; //ratio of cell height, should between [1.0f, 2.0f], default is 1.5f;
 
+
+/**
+ 
+ Use this method for dealloc visibles cells
+ On your ViewController on dealloc call this method.
+ 
+ e.g.
+ 
+ 
+ - (void)dealloc {
+    for (MMParallaxCell *cell in self.tableView.visibleCells) {
+        [cell safeRemoveObserver];
+    }
+ }
+ 
+ 
+ It will be fix the retain cycle, deallocing all cells in memory
+ 
+ 
+ */
 - (void)safeRemoveObserver;
 
 @end

--- a/Classes/MMParallaxCell.h
+++ b/Classes/MMParallaxCell.h
@@ -14,4 +14,6 @@
 
 @property (nonatomic, assign) CGFloat parallaxRatio; //ratio of cell height, should between [1.0f, 2.0f], default is 1.5f;
 
+- (void)safeRemoveObserver;
+
 @end

--- a/Classes/MMParallaxCell.m
+++ b/Classes/MMParallaxCell.m
@@ -28,6 +28,7 @@
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
 	[self setup];
 }
 


### PR DESCRIPTION
 Use this method for dealloc visibles cells
 On your ViewController on **dealloc** call this method.
 
 e.g.
 
 
```
 - (void)dealloc {
    for (MMParallaxCell *cell in self.tableView.visibleCells) {
        [cell safeRemoveObserver];
    }
 }
```
 
 
 It will be fix the retain cycle, deallocing all cells in memory